### PR TITLE
Fix a bug that can't put a script which includes UTF-8 characters

### DIFF
--- a/lib/managesieve.rb
+++ b/lib/managesieve.rb
@@ -95,7 +95,7 @@ class SieveResponseError < Exception; end
 #  __EOF__
 #
 #  # Test if there's enough space for script 'foobar'
-#  puts m.have_space?('foobar', script.length)
+#  puts m.have_space?('foobar', script.bytesize)
 #
 #  # Upload it
 #  m.put_script('foobar', script)
@@ -339,7 +339,7 @@ class ManageSieve
 
   private
   def sieve_string(string) # :nodoc:
-    return "{#{string.length}+}\r\n#{string}"
+    return "{#{string.bytesize}+}\r\n#{string}"
   end
 
   private


### PR DESCRIPTION
String#length returns the character length of the string, not
bytes since Ruby 1.9. On sending a string via ManageSieve, later
one is required. Please see the following documents for more
detail:

RFC 5804 Section 1.2.
https://tools.ietf.org/html/rfc5804#section-1.2

RFC 2244 Section 2.6.3.
http://www.rfc-editor.org/rfc/rfc2244.txt
